### PR TITLE
feat : #36 ModelCentric 설정파일, EfficientNet용 trainer 2단 파인튜닝 로직 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,5 @@ CLAUDE.md
 state.yaml
 
 # Configs
-configs/experiment_model.yaml
 configs/experiment_threshold.yaml
 

--- a/configs/experiment_model_centric.yaml
+++ b/configs/experiment_model_centric.yaml
@@ -1,0 +1,37 @@
+stage: 4
+
+training:
+  checkpoint_dir: experiments/model_centric/checkpoints
+  log_dir: experiments/model_centric/logs
+  epochs: 30
+  lr: 0.001          # Phase 1: classifier only
+  phase2_lr: 0.0001  # Phase 2: full fine-tuning
+  frozen_epochs: 5
+  weight_decay: 0.0001
+  early_stopping_patience: 10
+  batch_size: 32
+
+model:
+  architecture: efficientnet_b0
+  num_classes: 1
+  dropout_rate: 0.2
+  pretrained: true
+  pretrained_source: imagenet
+  freeze_backbone: true
+
+augmentation:
+  train:
+    letterbox: true
+    clahe_p: 0.5
+    clahe_clip_limit: 2.0
+    horizontal_flip_p: 0.5
+    brightness_contrast_p: 0.4
+    normalize_mean: [0.485, 0.456, 0.406]
+    normalize_std: [0.229, 0.224, 0.225]
+  val:
+    normalize_mean: [0.485, 0.456, 0.406]
+    normalize_std: [0.229, 0.224, 0.225]
+
+loss:
+  type: bce_with_logits
+  pos_weight: null

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -193,12 +193,32 @@ class Trainer:
             }
         """
         epochs = self.cfg.training.epochs
+        frozen_epochs = self.cfg.training.get("frozen_epochs", 0)
+        phase2_lr = self.cfg.training.get("phase2_lr", self.cfg.training.lr)
         history: list[dict] = []
         best_epoch = 0
 
         self.logger.info(f"학습 시작 — device={self.device}, epochs={epochs}, patience={self.patience}")
+        if frozen_epochs > 0:
+            self.logger.info(f"Phase 1: epoch 1~{frozen_epochs} — classifier only (lr={self.cfg.training.lr})")
 
         for epoch in range(1, epochs + 1):
+            # Phase 전환: frozen_epochs 완료 후 전체 레이어 학습 재개
+            if frozen_epochs > 0 and epoch == frozen_epochs + 1:
+                if hasattr(self.model, "unfreeze_backbone"):
+                    self.model.unfreeze_backbone()
+                    self.logger.info(f"Epoch {epoch}: Phase 2 — full fine-tuning 시작 (lr={phase2_lr})")
+                self.optimizer = optim.Adam(
+                    filter(lambda p: p.requires_grad, self.model.parameters()),
+                    lr=phase2_lr,
+                    weight_decay=self.cfg.training.weight_decay,
+                )
+                self.scheduler = CosineAnnealingLR(
+                    self.optimizer,
+                    T_max=epochs - frozen_epochs,
+                )
+                self.patience_counter = 0
+
             train_loss = self._train_epoch(train_loader)
             val_loss, val_metrics = self._eval_epoch(val_loader)
             self.scheduler.step()


### PR DESCRIPTION
Model-Centric 을 위한 config 파일 추가, trainer에 2단계 파인튜닝 로직 추가.

- configs/experiment_model_centric.yaml 추가
  - ImageNet 정규화 값 명시 (mean=[0.485,0.456,0.406], std=[0.229,0.224,0.225])
  - Phase 1/2 lr 설정 (lr=0.001, phase2_lr=0.0001)
  - letterbox + Stage 3 증강 파이프라인 유지
 
- src/training/trainer.py 수정
  - fit() 내 phase 전환 로직 추가 (frozen_epochs 완료 시, unfreeze_backbone 호출)
  - Phase 2 진입 시, optimizer/scheduler 재생성 및 patience_counter 리셋