### PR TITLE
feat : #52 ElasticTransform 증강 파이프라인

### DIFF
--- a/configs/experiment_additional_elastic.yaml
+++ b/configs/experiment_additional_elastic.yaml
@@ -1,0 +1,43 @@
+stage: 6
+experiment_name: additional_elastic
+
+training:
+  checkpoint_dir: experiments/additional/elastic/checkpoints
+  log_dir: experiments/additional/elastic/logs
+  epochs: 30
+  lr: 0.001          # Phase 1: classifier only
+  phase2_lr: 0.0001  # Phase 2: full fine-tuning
+  frozen_epochs: 5
+  weight_decay: 0.0001
+  early_stopping_patience: 10
+  batch_size: 32
+
+model:
+  architecture: efficientnet_b0
+  num_classes: 1
+  dropout_rate: 0.2
+  pretrained: true
+  pretrained_source: imagenet
+  freeze_backbone: true
+
+augmentation:
+  train:
+    letterbox: true
+    clahe_p: 0.5
+    clahe_clip_limit: 2.0
+    # ElasticTransform: Stage 3 BaselineCNN에서는 효과 없었으나, EfficientNet-B0은
+    # ImageNet 사전학습으로 풍부한 특징 표현을 보유하여 과소적합 위험이 낮음.
+    # 결함 형태 미세 변형이 정규화 효과로 작용할 것으로 기대.
+    # alpha=1, sigma=50은 transforms.py에서 고정 — 식별 가능한 수준의 약한 변형.
+    elastic_p: 0.15
+    horizontal_flip_p: 0.5
+    brightness_contrast_p: 0.4
+    normalize_mean: [0.485, 0.456, 0.406]
+    normalize_std: [0.229, 0.224, 0.225]
+  val:
+    normalize_mean: [0.485, 0.456, 0.406]
+    normalize_std: [0.229, 0.224, 0.225]
+
+loss:
+  type: bce_with_logits
+  pos_weight: null

--- a/src/data/dataset.py
+++ b/src/data/dataset.py
@@ -13,6 +13,7 @@ from torch.utils.data import DataLoader, Dataset
 
 from src.data.samplers import build_weighted_sampler
 from src.data.transforms import (
+    get_additional_elastic_train_transforms,
     get_data_centric_train_transforms,
     get_data_centric_train_transforms_no_letterbox,
     get_data_centric_val_transforms,
@@ -126,7 +127,8 @@ def build_dataloaders(
 ) -> tuple[DataLoader, DataLoader, DataLoader]:
     """cfg에서 train/val/test DataLoader를 생성하여 반환한다.
 
-    Stage 3 Data-Centric 모드 지원:
+    Stage 3+ Data-Centric 모드 지원:
+        - cfg.augmentation.train.letterbox == True이고 elastic_p > 0이면 Stage 6 ElasticTransform 파이프라인 사용
         - cfg.augmentation.train.letterbox == True이면 Stage 3 강화 증강 파이프라인 사용
         - cfg.data.use_weighted_sampler == True이면 WeightedRandomSampler 적용 (shuffle=False)
 
@@ -139,8 +141,13 @@ def build_dataloaders(
     # 증강 파이프라인 선택
     use_letterbox: bool = cfg.augmentation.train.get("letterbox", False)
     use_clahe: bool = cfg.augmentation.train.get("clahe_p", 0) > 0
+    use_elastic: bool = cfg.augmentation.train.get("elastic_p", 0) > 0
 
-    if use_letterbox:
+    if use_letterbox and use_elastic:
+        # Stage 6 ElasticTransform 실험: 레터박스 + CLAHE + ElasticTransform 모드
+        train_transform = get_additional_elastic_train_transforms(cfg)
+        val_transform = get_data_centric_val_transforms(cfg)
+    elif use_letterbox:
         # 레터박스 + CLAHE 모드
         train_transform = get_data_centric_train_transforms(cfg)
         val_transform = get_data_centric_val_transforms(cfg)

--- a/src/data/transforms.py
+++ b/src/data/transforms.py
@@ -95,6 +95,65 @@ def get_data_centric_train_transforms_no_letterbox(cfg: DictConfig) -> A.Compose
     return A.Compose(transforms)
 
 
+def get_additional_elastic_train_transforms(cfg: DictConfig) -> A.Compose:
+    """Stage 6 ElasticTransform 실험용 학습 증강 파이프라인 — 레터박스 모드.
+
+    근거: Stage 3 Data-Centric에서 BaselineCNN 대상 ElasticTransform은 효과 없었으나,
+    EfficientNet-B0은 ImageNet 사전학습으로 풍부한 특징 표현을 보유해
+    과소적합 위험이 낮음. 결함 형태 미세 변형이 정규화 효과로 작용할 가능성.
+    기대효과: 과적합 감소 → val/test F1 향상.
+
+    alpha=1, sigma=50은 결함이 육안으로 식별 가능한 수준의 약한 변형을 보장한다.
+    elastic_p는 cfg.augmentation.train.elastic_p에서 읽으며 기본값 0.15.
+
+    Args:
+        cfg: resolve_normalization() 처리가 완료된 OmegaConf 설정
+
+    Returns:
+        A.Compose 변환 객체
+    """
+    aug_cfg = cfg.augmentation.train
+    h, w = cfg.data.image_size
+
+    mean = list(cfg.augmentation.val.normalize_mean)
+    std = list(cfg.augmentation.val.normalize_std)
+
+    clahe_p: float = aug_cfg.get("clahe_p", 0.5)
+    clahe_clip_limit: float = aug_cfg.get("clahe_clip_limit", 2.0)
+    elastic_p: float = aug_cfg.get("elastic_p", 0.15)
+    rotate_p: float = aug_cfg.get("rotate_p", 0.0)
+    rotate_limit: int = aug_cfg.get("rotate_limit", 0)
+    brightness_contrast_p: float = aug_cfg.get("brightness_contrast_p", 0.4)
+    hflip_p: float = aug_cfg.get("horizontal_flip_p", 0.5)
+
+    transforms = [
+        # 레터박스 리사이즈: 평균 픽셀값(≈186)으로 패딩 — 정규화 후 ~0(중립)
+        A.LongestMaxSize(max_size=max(h, w)),
+        A.PadIfNeeded(
+            min_height=h,
+            min_width=w,
+            border_mode=0,
+            fill=186,
+        ),
+        A.CLAHE(clip_limit=clahe_clip_limit, p=clahe_p),
+        # ElasticTransform: alpha=1(변위 강도), sigma=50(변형 부드러움) — 약한 변형
+        A.ElasticTransform(alpha=1, sigma=50, p=elastic_p),
+        A.ShiftScaleRotate(
+            shift_limit=0.05,
+            scale_limit=0.05,
+            rotate_limit=rotate_limit,
+            border_mode=0,
+            p=rotate_p,
+        ),
+        A.RandomBrightnessContrast(p=brightness_contrast_p),
+        A.HorizontalFlip(p=hflip_p),
+        A.Normalize(mean=mean, std=std, max_pixel_value=255.0),
+        ToTensorV2(),
+    ]
+
+    return A.Compose(transforms)
+
+
 def get_data_centric_val_transforms(cfg: DictConfig) -> A.Compose:
     """Stage 3 검증/테스트용 변환 — 레터박스 모드.
 


### PR DESCRIPTION
ElasticTransform을 train aug에 추가하고 재학습

- src/data/transforms.py : ElasticTransform 지원 추가
- configs/experiment_additinal_elastic.yaml

참고
- Data-Centric 개선 파트에서 ElasticTransform을 시도했었으나 베이스라인CNN에서는 기대 효과 나타나지 못했었음.
- EfficientNet은 ImageNet 사전학습으로 이미 여러 특징 표현을 보유했기에, 과소적합 위험이 낮고, 결함 형태 변형이 정규화 효과로 작용할 가능성 높음.