### PR TITLE
feat : #54 VerticalFlip 실험용 증강 파이프라인 추가

### DIFF
--- a/configs/experiment_additional_vflip.yaml
+++ b/configs/experiment_additional_vflip.yaml
@@ -1,0 +1,42 @@
+stage: 6
+experiment_name: additional_vflip
+
+training:
+  checkpoint_dir: experiments/additional/vflip/checkpoints
+  log_dir: experiments/additional/vflip/logs
+  epochs: 30
+  lr: 0.001          # Phase 1: classifier only
+  phase2_lr: 0.0001  # Phase 2: full fine-tuning
+  frozen_epochs: 5
+  weight_decay: 0.0001
+  early_stopping_patience: 10
+  batch_size: 32
+
+model:
+  architecture: efficientnet_b0
+  num_classes: 1
+  dropout_rate: 0.2
+  pretrained: true
+  pretrained_source: imagenet
+  freeze_backbone: true
+
+augmentation:
+  train:
+    letterbox: true
+    clahe_p: 0.5
+    clahe_clip_limit: 2.0
+    horizontal_flip_p: 0.5
+    # VerticalFlip: KolektorSDD 결함은 표면 위치가 수직 방향으로도 무작위 분포.
+    # 수직 비대칭성이 없으므로 물리적으로 타당한 증강.
+    # 기대효과: 결함 위치 불변성 강화 → 과적합 감소, 일반화 성능 향상.
+    vertical_flip_p: 0.5
+    brightness_contrast_p: 0.4
+    normalize_mean: [0.485, 0.456, 0.406]
+    normalize_std: [0.229, 0.224, 0.225]
+  val:
+    normalize_mean: [0.485, 0.456, 0.406]
+    normalize_std: [0.229, 0.224, 0.225]
+
+loss:
+  type: bce_with_logits
+  pos_weight: null

--- a/src/data/dataset.py
+++ b/src/data/dataset.py
@@ -14,6 +14,7 @@ from torch.utils.data import DataLoader, Dataset
 from src.data.samplers import build_weighted_sampler
 from src.data.transforms import (
     get_additional_elastic_train_transforms,
+    get_additional_vflip_train_transforms,
     get_data_centric_train_transforms,
     get_data_centric_train_transforms_no_letterbox,
     get_data_centric_val_transforms,
@@ -129,6 +130,7 @@ def build_dataloaders(
 
     Stage 3+ Data-Centric 모드 지원:
         - cfg.augmentation.train.letterbox == True이고 elastic_p > 0이면 Stage 6 ElasticTransform 파이프라인 사용
+        - cfg.augmentation.train.letterbox == True이고 vertical_flip_p > 0이면 Stage 6 VerticalFlip 파이프라인 사용
         - cfg.augmentation.train.letterbox == True이면 Stage 3 강화 증강 파이프라인 사용
         - cfg.data.use_weighted_sampler == True이면 WeightedRandomSampler 적용 (shuffle=False)
 
@@ -142,10 +144,15 @@ def build_dataloaders(
     use_letterbox: bool = cfg.augmentation.train.get("letterbox", False)
     use_clahe: bool = cfg.augmentation.train.get("clahe_p", 0) > 0
     use_elastic: bool = cfg.augmentation.train.get("elastic_p", 0) > 0
+    use_vflip: bool = cfg.augmentation.train.get("vertical_flip_p", 0) > 0
 
     if use_letterbox and use_elastic:
         # Stage 6 ElasticTransform 실험: 레터박스 + CLAHE + ElasticTransform 모드
         train_transform = get_additional_elastic_train_transforms(cfg)
+        val_transform = get_data_centric_val_transforms(cfg)
+    elif use_letterbox and use_vflip:
+        # Stage 6 VerticalFlip 실험: 레터박스 + CLAHE + HorizontalFlip + VerticalFlip 모드
+        train_transform = get_additional_vflip_train_transforms(cfg)
         val_transform = get_data_centric_val_transforms(cfg)
     elif use_letterbox:
         # 레터박스 + CLAHE 모드

--- a/src/data/transforms.py
+++ b/src/data/transforms.py
@@ -154,6 +154,63 @@ def get_additional_elastic_train_transforms(cfg: DictConfig) -> A.Compose:
     return A.Compose(transforms)
 
 
+def get_additional_vflip_train_transforms(cfg: DictConfig) -> A.Compose:
+    """Stage 6 VerticalFlip 실험용 증강 파이프라인 — 레터박스 모드.
+
+    근거: KolektorSDD 결함은 표면 위치가 수직 방향으로도 무작위 분포.
+    수직 비대칭성이 없으므로 VerticalFlip 추가는 물리적으로 타당함.
+    기대효과: 결함 위치 불변성 강화 → 과적합 감소, 일반화 성능 향상.
+
+    vertical_flip_p는 cfg.augmentation.train.vertical_flip_p에서 읽으며 기본값 0.5.
+
+    Args:
+        cfg: resolve_normalization() 처리가 완료된 OmegaConf 설정
+
+    Returns:
+        A.Compose 변환 객체
+    """
+    aug_cfg = cfg.augmentation.train
+    h, w = cfg.data.image_size
+
+    mean = list(cfg.augmentation.val.normalize_mean)
+    std = list(cfg.augmentation.val.normalize_std)
+
+    clahe_p: float = aug_cfg.get("clahe_p", 0.5)
+    clahe_clip_limit: float = aug_cfg.get("clahe_clip_limit", 2.0)
+    rotate_p: float = aug_cfg.get("rotate_p", 0.0)
+    rotate_limit: int = aug_cfg.get("rotate_limit", 0)
+    brightness_contrast_p: float = aug_cfg.get("brightness_contrast_p", 0.4)
+    hflip_p: float = aug_cfg.get("horizontal_flip_p", 0.5)
+    vflip_p: float = aug_cfg.get("vertical_flip_p", 0.5)
+
+    transforms = [
+        # 레터박스 리사이즈: 평균 픽셀값(≈186)으로 패딩 — 정규화 후 ~0(중립)
+        A.LongestMaxSize(max_size=max(h, w)),
+        A.PadIfNeeded(
+            min_height=h,
+            min_width=w,
+            border_mode=0,
+            fill=186,
+        ),
+        A.CLAHE(clip_limit=clahe_clip_limit, p=clahe_p),
+        A.ShiftScaleRotate(
+            shift_limit=0.05,
+            scale_limit=0.05,
+            rotate_limit=rotate_limit,
+            border_mode=0,
+            p=rotate_p,
+        ),
+        A.RandomBrightnessContrast(p=brightness_contrast_p),
+        A.HorizontalFlip(p=hflip_p),
+        # VerticalFlip: KolektorSDD 결함 수직 위치 무작위성 반영 — 수직 비대칭성 없음
+        A.VerticalFlip(p=vflip_p),
+        A.Normalize(mean=mean, std=std, max_pixel_value=255.0),
+        ToTensorV2(),
+    ]
+
+    return A.Compose(transforms)
+
+
 def get_data_centric_val_transforms(cfg: DictConfig) -> A.Compose:
     """Stage 3 검증/테스트용 변환 — 레터박스 모드.
 


### PR DESCRIPTION
VerticalFlip을 추가하고 재학습

- src/data/transforms.py : VerticalFlip 지원 추가
- configs/experiment_additional_vflip.yaml : vertical_flip_p = 0.5 설정

참고
- 현재 파이프라인은 horizontal flip(좌우반전)만 적용 중.
- Vertical Flip 추가 시 학습 데이터 다양성 증가로, 모델이 결함 위치에 덜 의존할 것으로 기대.